### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Cargo Build & Test
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/hamishmorgan/swizzle/security/code-scanning/1](https://github.com/hamishmorgan/swizzle/security/code-scanning/1)

**How to fix the problem in general:**  
Add a `permissions` key specifying the minimal required privileges for the workflow. For typical CI workflows (build, test, lint, generate docs) that do not modify repository contents or interact with GitHub resources in a write mode, `contents: read` is usually sufficient.

**Best way to fix this instance:**  
Add `permissions: contents: read` at the root of the workflow (right after the `name:` declaration and before `on:`), ensuring that all jobs in the workflow inherit this minimal permission set. This does not change any existing functionality but restricts the implicit privilege level.

**What to change:**  
Edit `.github/workflows/rust.yml` to add:
```yaml
permissions:
  contents: read
```
after the `name: Cargo Build & Test` line and before `on:`. No further changes are required, since none of the current steps require greater permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `permissions: contents: read` to `.github/workflows/rust.yml` to restrict workflow privileges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1f2cf444532bf804d3c1f6618a9fe5114cd20f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->